### PR TITLE
Create basic swagger example using Belly infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,21 +11,32 @@
   <reporting>
     <plugins>
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
-          <configuration>
-            <configLocation>${project.basedir}/src/main/resources/checkstyle_checks.xml</configLocation>
-            <suppressionsLocation>${project.basedir}/src/main/resources/suppressions.xml</suppressionsLocation>
-          </configuration>
-        </plugin>
-      </plugins>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.17</version>
+        <configuration>
+          <configLocation>${project.basedir}/src/main/resources/checkstyle_checks.xml</configLocation>
+          <suppressionsLocation>${project.basedir}/src/main/resources/suppressions.xml</suppressionsLocation>
+        </configuration>
+      </plugin>
+    </plugins>
   </reporting>
 
   <repositories>
     <repository>
       <id>sonatype-snapshots</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+
+    <repository>
+      <id>manusant-beerRepo</id>
+      <url>https://packagecloud.io/manusant/beerRepo/maven2</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -97,6 +108,17 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.beerboy.ss</groupId>
+      <artifactId>spark-swagger</artifactId>
+      <version>1.0.0.48</version>
+    </dependency>
+     <dependency>
+      <groupId>com.beerboy.spark</groupId>
+      <artifactId>spark-typify</artifactId>
+      <version>1.0.0.5</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.puppycrawl.tools</groupId>
       <artifactId>checkstyle</artifactId>
       <version>8.25</version>
@@ -149,7 +171,6 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>

--- a/src/main/java/unrc/dose/App.java
+++ b/src/main/java/unrc/dose/App.java
@@ -1,33 +1,50 @@
 package unrc.dose;
 
-import static spark.Spark.get;
-import static spark.Spark.post;
-import static spark.Spark.before;
 import static spark.Spark.after;
-import static spark.Spark.options;
+import static spark.Spark.before;
+import static spark.Spark.get;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import org.javalite.activejdbc.Base;
-import org.javalite.activejdbc.DB;
 import org.javalite.activejdbc.LazyList;
 
-import unrc.dose.User;
+import com.beerboy.ss.SparkSwagger;
+import spark.Service;
 
 public class App
 {
     public static void main( String[] args ) {
+      Service spark = Service.ignite().port(55555);
+
+      try {
+        SparkSwagger
+          .of(spark)
+          .endpoints(() -> Arrays.asList(new BellyEndpoint()))
+          .generateDoc();
+      }
+      catch(IOException e) {
+        e.printStackTrace();
+      }
+
       before((request, response) -> {
-        Base.open();
+        if (!Base.hasConnection()) {
+          Base.open();
+        }
       });
 
       after((request, response) -> {
-        Base.close();
+        if (Base.hasConnection()) {
+          Base.close();
+        }
       });
 
-      get("/hello/:name", (req, res) -> {
+      spark.get("/hello/:name", (req, res) -> {
         return "hello" + req.params(":name");
       });
 
-      get("/users", (req, res) -> {
+      spark.get("/users", (req, res) -> {
         res.type("application/json");
 
         LazyList<User> users = User.findAll();

--- a/src/main/java/unrc/dose/Belly.java
+++ b/src/main/java/unrc/dose/Belly.java
@@ -1,17 +1,45 @@
+/**
+ * This is the main project package
+ *
+ * @author franco
+ * @version 0.1
+ */
 package unrc.dose;
 
 /** This is just an example class. */
 public class Belly {
-  private static final int capacity = 40;
+  /** Belly's capacity. */
+  private static final int CAPACITY = 40;
+
   /** keeps the value of the current level of elements into Belly. */
   private int current;
 
-  public void eat(int cukes) {
+  /** Belly identifier. */
+  private int id;
+
+  /** Belly's owner. */
+  private String name;
+
+  /** Constructor.
+   * @param id Identifier
+   * @param name slug
+  */
+  public Belly(final int id, final String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  /** Adds cukes into belly.
+   * @param cukes int
+   */
+  public void eat(final int cukes) {
     current = cukes;
   }
 
+  /** Checks if belly is full.
+   * @return boolean
+   */
   public boolean isFull() {
-    return capacity <= current;
+    return CAPACITY <= current;
   }
-
 }

--- a/src/main/java/unrc/dose/BellyEndpoint.java
+++ b/src/main/java/unrc/dose/BellyEndpoint.java
@@ -1,0 +1,56 @@
+package unrc.dose;
+
+import com.beerboy.ss.SparkSwagger;
+import com.beerboy.ss.rest.Endpoint;
+import com.google.gson.Gson;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.beerboy.ss.descriptor.EndpointDescriptor.endpointPath;
+import static com.beerboy.ss.descriptor.MethodDescriptor.path;
+
+/** Endpoint wrapping everything related to Bellies. */
+public final class BellyEndpoint implements Endpoint {
+    /** logger... */
+    static final Logger LOGGER = LoggerFactory.getLogger(BellyEndpoint.class);
+
+    /** main namespace of this endpoint. */
+    private static final String NAME_SPACE = "/belly";
+
+    /** service used to manipulate in memory the bellies. */
+    private static BellyService bellyService = new BellyService();
+
+    @Override
+    public void bind(final SparkSwagger restApi) {
+
+        restApi.endpoint(
+            endpointPath(NAME_SPACE)
+                .withDescription(
+                    "belly REST API exposing all bellies utilities"
+                ),
+            (q, a) -> LOGGER.info("Logging Received request for Belly Rest API")
+        )
+        .get(
+            path("/export")
+                .withDescription("Will return all bellies in the store")
+                .withResponseType(String.class),
+            (req, res) -> {
+                return new Gson().toJson(bellyService.findAll());
+            }
+        )
+        .post(
+            path("")
+                .withDescription("Creates a new Belly")
+                .withQueryParam()
+                    .withName("name")
+                    .withDescription("Belly's owner").and()
+                .withResponseType(Belly.class),
+            (req, res) -> {
+                return new Gson().toJson(
+                    bellyService.add(req.queryParams("name"))
+                );
+            }
+        );
+    }
+}

--- a/src/main/java/unrc/dose/BellyService.java
+++ b/src/main/java/unrc/dose/BellyService.java
@@ -1,0 +1,63 @@
+package unrc.dose;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** This is a Service to store a bunch of Bellies together. */
+public final class BellyService {
+
+    /** Bellies store. */
+    private static Map<String, Belly> bellies = new HashMap<String, Belly>();
+
+    /** Atomic counter. */
+    private static final AtomicInteger COUNT = new AtomicInteger(0);
+
+    /** Returns a particular belly.
+     * @param id String
+     * @return Belly
+    */
+    public Belly findById(final String id) {
+        return (Belly) bellies.get(id);
+    }
+
+    /** Adds a belly to store.
+     * @param name String
+     * @return Belly
+    */
+    public Belly add(final String name) {
+        int currentId = COUNT.incrementAndGet();
+        Belly belly = new Belly(currentId, name);
+        bellies.put(String.valueOf(currentId), belly);
+        return belly;
+    }
+
+    /** Updates a belly.
+     * @param id String
+     * @param cukes int
+     * @return Belly
+    */
+    public Belly update(final String id, final int cukes) {
+        Belly belly = (Belly) bellies.get(id);
+        belly.eat(cukes);
+        bellies.put(id, belly);
+
+        return belly;
+    }
+
+    /** Deletes Belly.
+     * @param id String
+    */
+    public void delete(final String id) {
+        bellies.remove(id);
+    }
+
+    /** Returns a list of bellies.
+     * @return List of bellies
+    */
+    public List findAll() {
+        return new ArrayList<>(bellies.values());
+    }
+}

--- a/src/main/resources/spark-swagger.conf
+++ b/src/main/resources/spark-swagger.conf
@@ -1,0 +1,45 @@
+spark-swagger {
+  # UI related configs
+  theme = "MUTED"
+  deepLinking = false
+  displayOperationId = false
+  defaultModelsExpandDepth = 1
+  defaultModelExpandDepth = 1
+  defaultModelRendering = "model"
+  displayRequestDuration = false
+  docExpansion = "LIST"
+  filter = true
+  operationsSorter = "alpha"
+  showExtensions = false
+  showCommonExtensions = false
+  tagsSorter = "alpha"
+
+  # API related configs
+  host = "localhost:55555"
+  basePath = "/prg"
+  docPath = "/doc"
+  info {
+    description = "API designed to serve all network operations"
+    version = "4.0.0.0.1"
+    title = "Program Repair Golf"
+    termsOfService = ""
+    schemes = ["HTTP", "HTTPS", "WS", "WSS"]
+    project {
+      groupId = "unrc.dose.prg"
+      artifactId = "unrc.dose"
+    }
+    contact {
+      name = "Example Team"
+      email = "example@team.com"
+      url = "example.team.com"
+    }
+    license {
+      name = "Apache 2.0"
+      url = "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+    externalDoc {
+      description = "Example Doc"
+      url="com.example.doc"
+    }
+  }
+}

--- a/src/test/java/unrc/dose/Steps.java
+++ b/src/test/java/unrc/dose/Steps.java
@@ -19,7 +19,7 @@ public class Steps extends StepUtils {
 
   @Given("^(?:I have|the user has) (\\d+) cukes in my belly$")
   public void i_have_cukes_in_my_belly(int cukes) throws Exception {
-    belly = new Belly();
+    belly = new Belly(1, "pedro");
     belly.eat(cukes);
   }
 


### PR DESCRIPTION
Here there is a basic example how to create a Swagger endpoint. This is just a regular endpoint but has the extension needed to create the automatic documentation to use swagger-ui.

[spark-swagger](https://github.com/manusant/spark-swagger) is the plugin used to generate the Swagger documentation needed to run into Swagger-UI. In the project Readme you can find documentation about method used to describe endpoint's parameters, responses and descriptions.

