### PR TITLE
Fix Swagger basePath

### DIFF
--- a/src/main/resources/spark-swagger.conf
+++ b/src/main/resources/spark-swagger.conf
@@ -16,7 +16,7 @@ spark-swagger {
 
   # API related configs
   host = "localhost:55555"
-  basePath = "/prg"
+  basePath = "/"
   docPath = "/doc"
   info {
     description = "API designed to serve all network operations"


### PR DESCRIPTION
Fix path in swagger configuration to make it points to `/` instead `/prg`